### PR TITLE
Fix npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "react-dom": "^16.3.1"
   },
   "dependencies": {
-    "@mattiasbuelens/web-streams-polyfill": "^0.2.0",
     "fetch-readablestream": "^0.2.0",
     "immutable": "^3.8.2",
     "mitt": "^1.1.2",

--- a/src/stream.js
+++ b/src/stream.js
@@ -2,17 +2,7 @@ import { List } from 'immutable';
 import mitt from 'mitt';
 import { convertBufferToLines, bufferConcat } from './utils';
 
-const fetcher = Promise.resolve().then(() =>
-  'ReadableStream' in self && 'body' in self.Response.prototype
-    ? self.fetch
-    : import('@mattiasbuelens/web-streams-polyfill/ponyfill').then(
-        ({ ReadableStream }) => {
-          self.ReadableStream = ReadableStream;
-
-          return import('fetch-readablestream');
-        }
-      )
-);
+const fetcher = Promise.resolve().then(() => self.fetch);
 
 export const recurseReaderAsEvent = async (reader, emitter) => {
   const result = await reader.read();


### PR DESCRIPTION
Removes problem line that was stopping npm install from working properly to fix installing this fork through npm as a dependency. This also removes some streaming capabilities from old browsers but eh worth it.