### PR TITLE
Adds ability for search to work like a browser search

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@mattiasbuelens/web-streams-polyfill": "^0.2.0",
     "fetch-readablestream": "^0.2.0",
+    "hotkeys-js": "^3.7.3",
     "immutable": "^3.8.2",
     "mitt": "^1.1.2",
     "prop-types": "^15.6.1",

--- a/src/components/LazyLog/README.md
+++ b/src/components/LazyLog/README.md
@@ -4,7 +4,7 @@ Normal log viewing using a `url`:
 const url = 'https://gist.githubusercontent.com/helfi92/96d4444aa0ed46c5f9060a789d316100/raw/ba0d30a9877ea5cc23c7afcd44505dbc2bab1538/typical-live_backing.log';
 
 <div style={{ height: 500, width: 902 }}>
-  <LazyLog extraLines={1} enableSearch url={url} caseInsensitive />
+  <LazyLog extraLines={1} enableSearch url={url} caseInsensitive captureHotKeys={true} searchLikeBrowser={true} />
 </div>
 ```
 

--- a/src/components/LazyLog/README.md
+++ b/src/components/LazyLog/README.md
@@ -4,7 +4,7 @@ Normal log viewing using a `url`:
 const url = 'https://gist.githubusercontent.com/helfi92/96d4444aa0ed46c5f9060a789d316100/raw/ba0d30a9877ea5cc23c7afcd44505dbc2bab1538/typical-live_backing.log';
 
 <div style={{ height: 500, width: 902 }}>
-  <LazyLog extraLines={1} enableSearch url={url} caseInsensitive captureHotKeys={true} searchLikeBrowser={true} highlight={5} />
+  <LazyLog extraLines={1} enableSearch url={url} caseInsensitive captureHotKeys={true} searchLikeBrowser={true} />
 </div>
 ```
 

--- a/src/components/LazyLog/README.md
+++ b/src/components/LazyLog/README.md
@@ -4,7 +4,7 @@ Normal log viewing using a `url`:
 const url = 'https://gist.githubusercontent.com/helfi92/96d4444aa0ed46c5f9060a789d316100/raw/ba0d30a9877ea5cc23c7afcd44505dbc2bab1538/typical-live_backing.log';
 
 <div style={{ height: 500, width: 902 }}>
-  <LazyLog extraLines={1} enableSearch url={url} caseInsensitive captureHotKeys={true} searchLikeBrowser={true} />
+  <LazyLog extraLines={1} enableSearch url={url} caseInsensitive captureHotKeys={true} searchLikeBrowser={true} highlight={5} />
 </div>
 ```
 

--- a/src/components/LazyLog/index.jsx
+++ b/src/components/LazyLog/index.jsx
@@ -182,6 +182,11 @@ export default class LazyLog extends Component {
      * Flag to enable/disable case insensitive search
      */
     caseInsensitive: bool,
+    /**
+     * If true, capture system hotkeys for searching the page (Cmd-F, Ctrl-F,
+     * etc.)
+     */
+    captureHotkeys: bool,
   };
 
   static defaultProps = {
@@ -213,6 +218,7 @@ export default class LazyLog extends Component {
     lineClassName: '',
     highlightLineClassName: '',
     caseInsensitive: false,
+    captureHotkeys: false,
   };
 
   static getDerivedStateFromProps(
@@ -701,6 +707,7 @@ export default class LazyLog extends Component {
             onFilterLinesWithMatches={this.handleFilterLinesWithMatches}
             resultsCount={resultLines.length}
             disabled={count === 0}
+            captureHotkeys={this.props.captureHotkeys}
           />
         )}
         <AutoSizer

--- a/src/components/LazyLog/index.jsx
+++ b/src/components/LazyLog/index.jsx
@@ -196,7 +196,8 @@ export default class LazyLog extends Component {
      * with the searched term, shift + enter goes backwards.
      * Also adds up and down arrows to search bar to jump
      * to the next and previous result.
-     * Defaults to false, which causes enter to toggle the filter instead.
+     * If false, enter toggles the filter instead.
+     * Defaults to true.
      */
     searchLikeBrowser: bool,
   };
@@ -231,7 +232,7 @@ export default class LazyLog extends Component {
     highlightLineClassName: '',
     caseInsensitive: false,
     captureHotKeys: false,
-    searchLikeBrowser: false,
+    searchLikeBrowser: true,
   };
 
   static getDerivedStateFromProps(

--- a/src/components/LazyLog/index.jsx
+++ b/src/components/LazyLog/index.jsx
@@ -637,12 +637,18 @@ export default class LazyLog extends Component {
         currentResultsPosition !== undefined &&
         resultLines[currentResultsPosition] === lineNumber
       ) {
+        let locationInLine = 0;
+        // Find the first occurance of the line number
+        // We use this to make sure we're only searching from where
+        // the line number first occurs to the currentResultsPosition below
+        const initialOccurance = resultLines.findIndex(
+          element => element === resultLines[currentResultsPosition]
+        );
+
         // This finds which word in the line should be the highlighted one.
         // For example, if we should be highlighting the 2nd match on line 18,
         // this would set locationInLine to 2.
-        let locationInLine = 0;
-
-        for (let i = 0; i < currentResultsPosition + 1; i += 1) {
+        for (let i = initialOccurance; i <= currentResultsPosition; i += 1) {
           if (resultLines[i] === lineNumber) {
             locationInLine += 1;
           }

--- a/src/components/LazyLog/index.jsx
+++ b/src/components/LazyLog/index.jsx
@@ -189,8 +189,8 @@ export default class LazyLog extends Component {
     captureHotkeys: bool,
     /**
      * If true, search like a browser search - enter jumps to the next line
-     * with the searched term, shift goes backwards.
-     * Defaults to false, which causes enter to filter results instead.
+     * with the searched term, shift + enter goes backwards.
+     * Defaults to false, which causes enter to toggle the filter instead.
      */
     searchLikeBrowser: bool,
   };
@@ -484,7 +484,16 @@ export default class LazyLog extends Component {
   }
 
   handleEnterPressed = () => {
-    const { resultLines, scrollToLine, currentResultsPosition } = this.state;
+    const {
+      resultLines,
+      scrollToLine,
+      currentResultsPosition,
+      isFilteringLinesWithMatches,
+    } = this.state;
+
+    if (!this.props.searchLikeBrowser) {
+      this.handleFilterLinesWithMatches(!isFilteringLinesWithMatches);
+    }
 
     // If we have search results
     if (resultLines) {

--- a/src/components/LazyLog/index.jsx
+++ b/src/components/LazyLog/index.jsx
@@ -190,7 +190,7 @@ export default class LazyLog extends Component {
      * If true, capture system hotkeys for searching the page (Cmd-F, Ctrl-F,
      * etc.)
      */
-    captureHotkeys: bool,
+    captureHotKeys: bool,
     /**
      * If true, search like a browser search - enter jumps to the next line
      * with the searched term, shift + enter goes backwards.
@@ -228,7 +228,7 @@ export default class LazyLog extends Component {
     lineClassName: '',
     highlightLineClassName: '',
     caseInsensitive: false,
-    captureHotkeys: false,
+    captureHotKeys: false,
     searchLikeBrowser: false,
   };
 
@@ -862,7 +862,7 @@ export default class LazyLog extends Component {
             onFilterLinesWithMatches={this.handleFilterLinesWithMatches}
             resultsCount={resultLines.length}
             disabled={count === 0}
-            captureHotkeys={this.props.captureHotkeys}
+            captureHotKeys={this.props.captureHotKeys}
             onEnter={this.handleEnterPressed}
             onShiftEnter={this.handleShiftEnterPressed}
           />

--- a/src/components/LazyLog/index.jsx
+++ b/src/components/LazyLog/index.jsx
@@ -522,16 +522,9 @@ export default class LazyLog extends Component {
   };
 
   handleShiftEnterPressed = () => {
-    const {
-      resultLines,
-      scrollToLine,
-      currentResultsPosition,
-      isFilteringLinesWithMatches,
-    } = this.state;
+    const { resultLines, scrollToLine, currentResultsPosition } = this.state;
 
     if (!this.props.searchLikeBrowser) {
-      this.handleFilterLinesWithMatches(!isFilteringLinesWithMatches);
-
       return;
     }
 

--- a/src/components/LazyLog/index.jsx
+++ b/src/components/LazyLog/index.jsx
@@ -465,6 +465,17 @@ export default class LazyLog extends Component {
     });
   };
 
+  handleScrollToLine(scrollToLine = 0) {
+    const scrollToIndex = getScrollIndex({
+      scrollToLine,
+    });
+
+    this.setState({
+      scrollToIndex,
+      scrollToLine,
+    });
+  }
+
   handleSearch = keywords => {
     const { resultLines, searchKeywords } = this.state;
     const { caseInsensitive, stream, websocket } = this.props;

--- a/src/components/LazyLog/index.jsx
+++ b/src/components/LazyLog/index.jsx
@@ -194,6 +194,8 @@ export default class LazyLog extends Component {
     /**
      * If true, search like a browser search - enter jumps to the next line
      * with the searched term, shift + enter goes backwards.
+     * Also adds up and down arrows to search bar to jump
+     * to the next and previous result.
      * Defaults to false, which causes enter to toggle the filter instead.
      */
     searchLikeBrowser: bool,
@@ -842,6 +844,7 @@ export default class LazyLog extends Component {
       isFilteringLinesWithMatches,
       filteredLines = List(),
       count,
+      currentResultsPosition,
     } = this.state;
     const rowCount = isFilteringLinesWithMatches ? filteredLines.size : count;
 
@@ -858,6 +861,8 @@ export default class LazyLog extends Component {
             captureHotKeys={this.props.captureHotKeys}
             onEnter={this.handleEnterPressed}
             onShiftEnter={this.handleShiftEnterPressed}
+            searchLikeBrowser={this.props.searchLikeBrowser}
+            currentResultsPosition={currentResultsPosition}
           />
         )}
         <AutoSizer

--- a/src/components/LazyLog/index.jsx
+++ b/src/components/LazyLog/index.jsx
@@ -515,6 +515,38 @@ export default class LazyLog extends Component {
     }
   };
 
+  handleShiftEnterPressed = () => {
+    const {
+      resultLines,
+      scrollToLine,
+      currentResultsPosition,
+      isFilteringLinesWithMatches,
+    } = this.state;
+
+    if (!this.props.searchLikeBrowser) {
+      this.handleFilterLinesWithMatches(!isFilteringLinesWithMatches);
+    }
+
+    // If we have search results
+    if (resultLines) {
+      // If we already scrolled to a line
+      if (scrollToLine) {
+        // Scroll to the previous line if possible,
+        // wrap to the bottom if we're at the top.
+
+        if (currentResultsPosition - 1 >= 0) {
+          this.handleScrollToLine(resultLines[currentResultsPosition - 1]);
+          this.setState({ currentResultsPosition: currentResultsPosition - 1 });
+
+          return;
+        }
+      }
+
+      this.handleScrollToLine(resultLines[resultLines.length - 1]);
+      this.setState({ currentResultsPosition: resultLines.length - 1 });
+    }
+  };
+
   handleSearch = keywords => {
     const { resultLines, searchKeywords } = this.state;
     const { caseInsensitive, stream, websocket } = this.props;
@@ -779,6 +811,7 @@ export default class LazyLog extends Component {
             disabled={count === 0}
             captureHotkeys={this.props.captureHotkeys}
             onEnter={this.handleEnterPressed}
+            onShiftEnter={this.handleShiftEnterPressed}
           />
         )}
         <AutoSizer

--- a/src/components/LazyLog/index.module.css
+++ b/src/components/LazyLog/index.module.css
@@ -15,3 +15,8 @@
   background-color: #ffff00;
   color: #222222;
 }
+
+.searchMatchHighlighted {
+  background-color: #FF10F0 ;
+  color: #222222;
+}

--- a/src/components/SearchBar/ArrowIcons/DownArrow/README.md
+++ b/src/components/SearchBar/ArrowIcons/DownArrow/README.md
@@ -1,0 +1,3 @@
+```js
+<DownArrowIcon />
+```

--- a/src/components/SearchBar/ArrowIcons/DownArrow/index.jsx
+++ b/src/components/SearchBar/ArrowIcons/DownArrow/index.jsx
@@ -1,0 +1,15 @@
+import { PureComponent } from 'react';
+import { downArrowIcon } from './index.module.css';
+
+export default class DownArrowIcon extends PureComponent {
+  render() {
+    return (
+      <svg
+        className={downArrowIcon}
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 115.4 122.88">
+        <path d="M24.94,55A14.66,14.66,0,0,0,4.38,75.91l43.45,42.76a14.66,14.66,0,0,0,20.56,0L111,76.73A14.66,14.66,0,0,0,90.46,55.82l-18,17.69-.29-59.17c-.1-19.28-29.42-19-29.33.24l.29,58.34L24.94,55Z" />
+      </svg>
+    );
+  }
+}

--- a/src/components/SearchBar/ArrowIcons/DownArrow/index.module.css
+++ b/src/components/SearchBar/ArrowIcons/DownArrow/index.module.css
@@ -1,0 +1,4 @@
+.downArrowIcon {
+  height: 15px;
+  cursor: pointer;
+}

--- a/src/components/SearchBar/ArrowIcons/UpArrow/README.md
+++ b/src/components/SearchBar/ArrowIcons/UpArrow/README.md
@@ -1,0 +1,3 @@
+```js
+<UpArrowIcon />
+```

--- a/src/components/SearchBar/ArrowIcons/UpArrow/index.jsx
+++ b/src/components/SearchBar/ArrowIcons/UpArrow/index.jsx
@@ -1,0 +1,15 @@
+import { PureComponent } from 'react';
+import { upArrowIcon } from './index.module.css';
+
+export default class UpArrowIcon extends PureComponent {
+  render() {
+    return (
+      <svg
+        className={upArrowIcon}
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 115.4 122.88">
+        <path d="M24.94,67.88A14.66,14.66,0,0,1,4.38,47L47.83,4.21a14.66,14.66,0,0,1,20.56,0L111,46.15A14.66,14.66,0,0,1,90.46,67.06l-18-17.69-.29,59.17c-.1,19.28-29.42,19-29.33-.25L43.14,50,24.94,67.88Z" />
+      </svg>
+    );
+  }
+}

--- a/src/components/SearchBar/ArrowIcons/UpArrow/index.module.css
+++ b/src/components/SearchBar/ArrowIcons/UpArrow/index.module.css
@@ -1,0 +1,4 @@
+.upArrowIcon {
+  height: 15px;
+  cursor: pointer;
+}

--- a/src/components/SearchBar/index.jsx
+++ b/src/components/SearchBar/index.jsx
@@ -1,5 +1,6 @@
-import { Component } from 'react';
+import { createRef, Component } from 'react';
 import { bool, func, number } from 'prop-types';
+import hotkeys from 'hotkeys-js';
 import FilterLinesIcon from './FilterLinesIcon';
 import { SEARCH_MIN_KEYWORDS } from '../../utils';
 import {
@@ -38,6 +39,11 @@ export default class SearchBar extends Component {
      * If true, the input field and filter button will be disabled.
      */
     disabled: bool,
+    /**
+     * If true, capture system hotkeys for searching the page (Cmd-F, Ctrl-F,
+     * etc.)
+     */
+    captureHotkeys: bool,
   };
 
   static defaultProps = {
@@ -47,11 +53,17 @@ export default class SearchBar extends Component {
     resultsCount: 0,
     filterActive: false,
     disabled: false,
+    captureHotkeys: false,
   };
 
   state = {
     keywords: '',
   };
+
+  constructor(props) {
+    super(props);
+    this.inputRef = createRef();
+  }
 
   handleFilterToggle = () => {
     this.props.onFilterLinesWithMatches(!this.props.filterActive);
@@ -80,6 +92,21 @@ export default class SearchBar extends Component {
     }
   };
 
+  handleSearchHotkey = e => {
+    if (!this.inputRef.current) {
+      return;
+    }
+
+    e.preventDefault();
+    this.inputRef.current.focus();
+  };
+
+  componentDidMount() {
+    if (this.props.captureHotkeys) {
+      hotkeys('ctrl+f,cmd+f', this.handleSearchHotkey);
+    }
+  }
+
   render() {
     const { resultsCount, filterActive, disabled } = this.props;
     const matchesLabel = `match${resultsCount === 1 ? '' : 'es'}`;
@@ -97,6 +124,7 @@ export default class SearchBar extends Component {
           onKeyPress={this.handleSearchKeyPress}
           value={this.state.keywords}
           disabled={disabled}
+          ref={this.inputRef}
         />
         <button
           disabled={disabled}

--- a/src/components/SearchBar/index.jsx
+++ b/src/components/SearchBar/index.jsx
@@ -46,9 +46,12 @@ export default class SearchBar extends Component {
     captureHotkeys: bool,
     /**
      * Exectues a function when enter is pressed.
-     * Defaults to turning the filter on and off.
      */
     onEnter: func,
+    /**
+     * Exectues a function when shift + enter is pressed.
+     */
+    onShiftEnter: func,
   };
 
   static defaultProps = {
@@ -82,7 +85,11 @@ export default class SearchBar extends Component {
 
   handleKeyPress = e => {
     if (e.key === 'Enter') {
-      this.props.onEnter();
+      if (e.shiftKey) {
+        this.props.onShiftEnter();
+      } else {
+        this.props.onEnter();
+      }
     } else if (this.props.captureHotkeys) {
       this.handleSearchHotkey(e);
     }
@@ -106,6 +113,15 @@ export default class SearchBar extends Component {
     } else {
       onClearSearch();
     }
+  };
+
+  handleSearchHotkey = e => {
+    if (!this.inputRef.current) {
+      return;
+    }
+
+    e.preventDefault();
+    this.inputRef.current.focus();
   };
 
   componentDidMount() {

--- a/src/components/SearchBar/index.jsx
+++ b/src/components/SearchBar/index.jsx
@@ -43,7 +43,7 @@ export default class SearchBar extends Component {
      * If true, capture system hotkeys for searching the page (Cmd-F, Ctrl-F,
      * etc.)
      */
-    captureHotkeys: bool,
+    captureHotKeys: bool,
     /**
      * Exectues a function when enter is pressed.
      */
@@ -61,7 +61,7 @@ export default class SearchBar extends Component {
     resultsCount: 0,
     filterActive: false,
     disabled: false,
-    captureHotkeys: false,
+    captureHotKeys: false,
   };
 
   state = {

--- a/src/components/SearchBar/index.jsx
+++ b/src/components/SearchBar/index.jsx
@@ -1,7 +1,9 @@
-import { createRef, Component } from 'react';
+import { createRef, Component, Fragment } from 'react';
 import { bool, func, number } from 'prop-types';
 import hotkeys from 'hotkeys-js';
 import FilterLinesIcon from './FilterLinesIcon';
+import DownArrowIcon from './ArrowIcons/DownArrow';
+import UpArrowIcon from './ArrowIcons/UpArrow';
 import { SEARCH_MIN_KEYWORDS } from '../../utils';
 import {
   searchBar,
@@ -52,6 +54,20 @@ export default class SearchBar extends Component {
      * Exectues a function when shift + enter is pressed.
      */
     onShiftEnter: func,
+    /**
+     * If true, search like a browser search - enter jumps to the next line
+     * with the searched term, shift + enter goes backwards.
+     * Also adds up and down arrows to search bar to jump
+     * to the next and previous result.
+     * Defaults to false, which causes enter to toggle the filter instead.
+     */
+    searchLikeBrowser: bool,
+    /**
+     * The current result the browser search is highlighting.
+     * Only applicable if searchLikeBrowser is true.
+     * Defaults to 1.
+     */
+    currentResultsPosition: number,
   };
 
   static defaultProps = {
@@ -62,6 +78,7 @@ export default class SearchBar extends Component {
     filterActive: false,
     disabled: false,
     captureHotKeys: false,
+    currentResultsPosition: 0,
   };
 
   state = {
@@ -121,9 +138,18 @@ export default class SearchBar extends Component {
   }
 
   render() {
-    const { resultsCount, filterActive, disabled } = this.props;
+    const {
+      resultsCount,
+      filterActive,
+      disabled,
+      searchLikeBrowser,
+      currentResultsPosition,
+      onEnter,
+      onShiftEnter,
+    } = this.props;
     const matchesLabel = `match${resultsCount === 1 ? '' : 'es'}`;
     const filterIcon = filterActive ? active : inactive;
+    const arrowIcon = resultsCount ? active : inactive;
 
     return (
       <div className={`react-lazylog-searchbar ${searchBar}`}>
@@ -148,11 +174,36 @@ export default class SearchBar extends Component {
           onMouseUp={this.handleFilterToggle}>
           <FilterLinesIcon />
         </button>
+        {searchLikeBrowser && (
+          <Fragment>
+            <button
+              disabled={disabled}
+              className={`react-lazylog-searchbar-up-arrow ${
+                resultsCount ? 'active' : 'inactive'
+              } ${button} ${arrowIcon}`}
+              onKeyPress={this.handleKeyPress}
+              onMouseUp={onShiftEnter}>
+              <UpArrowIcon />
+            </button>
+            <button
+              disabled={disabled}
+              className={`react-lazylog-searchbar-down-arrow ${
+                resultsCount ? 'active' : 'inactive'
+              } ${button} ${arrowIcon}`}
+              onKeyPress={this.handleKeyPress}
+              onMouseUp={onEnter}>
+              <DownArrowIcon />
+            </button>
+          </Fragment>
+        )}
+
         <span
           className={`react-lazylog-searchbar-matches ${
             resultsCount ? 'active' : 'inactive'
           } ${resultsCount ? active : inactive}`}>
-          {resultsCount} {matchesLabel}
+          {searchLikeBrowser && resultsCount
+            ? `${currentResultsPosition + 1} of ${resultsCount} ${matchesLabel}`
+            : `${resultsCount} ${matchesLabel}`}
         </span>
       </div>
     );

--- a/src/components/SearchBar/index.jsx
+++ b/src/components/SearchBar/index.jsx
@@ -187,8 +187,7 @@ export default class SearchBar extends Component {
               className={`react-lazylog-searchbar-up-arrow ${
                 resultsCount ? `active ${clickable}` : 'inactive'
               } ${button} ${arrowIcon}`}
-              onKeyPress={this.handleKeyPress}
-              onMouseUp={onShiftEnter}>
+              onClick={onShiftEnter}>
               <UpArrowIcon />
             </button>
             <button
@@ -196,8 +195,7 @@ export default class SearchBar extends Component {
               className={`react-lazylog-searchbar-down-arrow ${
                 resultsCount ? `active ${clickable}` : 'inactive'
               } ${button} ${arrowIcon}`}
-              onKeyPress={this.handleKeyPress}
-              onMouseUp={onEnter}>
+              onClick={onEnter}>
               <DownArrowIcon />
             </button>
           </Fragment>

--- a/src/components/SearchBar/index.jsx
+++ b/src/components/SearchBar/index.jsx
@@ -115,15 +115,6 @@ export default class SearchBar extends Component {
     }
   };
 
-  handleSearchHotkey = e => {
-    if (!this.inputRef.current) {
-      return;
-    }
-
-    e.preventDefault();
-    this.inputRef.current.focus();
-  };
-
   componentDidMount() {
     if (this.props.captureHotkeys) {
       hotkeys('ctrl+f,cmd+f', this.handleSearchHotkey);
@@ -154,7 +145,8 @@ export default class SearchBar extends Component {
           className={`react-lazylog-searchbar-filter ${
             filterActive ? 'active' : 'inactive'
           } ${button} ${filterIcon}`}
-          onClick={this.handleFilterToggle}>
+          onKeyPress={this.handleKeyPress}
+          onMouseUp={this.handleFilterToggle}>
           <FilterLinesIcon />
         </button>
         <span

--- a/src/components/SearchBar/index.jsx
+++ b/src/components/SearchBar/index.jsx
@@ -76,6 +76,10 @@ export default class SearchBar extends Component {
     this.setState({ keywords }, () => this.search());
   };
 
+  handleFilterToggle = () => {
+    this.props.onFilterLinesWithMatches(!this.props.filterActive);
+  };
+
   handleKeyPress = e => {
     if (e.key === 'Enter') {
       this.props.onEnter();

--- a/src/components/SearchBar/index.jsx
+++ b/src/components/SearchBar/index.jsx
@@ -44,6 +44,11 @@ export default class SearchBar extends Component {
      * etc.)
      */
     captureHotkeys: bool,
+    /**
+     * Exectues a function when enter is pressed.
+     * Defaults to turning the filter on and off.
+     */
+    onEnter: func,
   };
 
   static defaultProps = {
@@ -75,10 +80,22 @@ export default class SearchBar extends Component {
     this.setState({ keywords }, () => this.search());
   };
 
-  handleSearchKeyPress = e => {
+  handleKeyPress = e => {
     if (e.key === 'Enter') {
-      this.handleFilterToggle();
+      // this.handleFilterToggle();
+      this.props.onEnter();
+    } else if (this.props.captureHotkeys) {
+      this.handleSearchHotkey(e);
     }
+  };
+
+  handleSearchHotkey = e => {
+    if (!this.inputRef.current) {
+      return;
+    }
+
+    e.preventDefault();
+    this.inputRef.current.focus();
   };
 
   search = () => {
@@ -90,15 +107,6 @@ export default class SearchBar extends Component {
     } else {
       onClearSearch();
     }
-  };
-
-  handleSearchHotkey = e => {
-    if (!this.inputRef.current) {
-      return;
-    }
-
-    e.preventDefault();
-    this.inputRef.current.focus();
   };
 
   componentDidMount() {
@@ -121,7 +129,7 @@ export default class SearchBar extends Component {
           placeholder="Search"
           className={`react-lazylog-searchbar-input ${searchInput}`}
           onChange={this.handleSearchChange}
-          onKeyPress={this.handleSearchKeyPress}
+          onKeyPress={this.handleKeyPress}
           value={this.state.keywords}
           disabled={disabled}
           ref={this.inputRef}

--- a/src/components/SearchBar/index.jsx
+++ b/src/components/SearchBar/index.jsx
@@ -90,8 +90,6 @@ export default class SearchBar extends Component {
       } else {
         this.props.onEnter();
       }
-    } else if (this.props.captureHotkeys) {
-      this.handleSearchHotkey(e);
     }
   };
 
@@ -116,8 +114,8 @@ export default class SearchBar extends Component {
   };
 
   componentDidMount() {
-    if (this.props.captureHotkeys) {
-      hotkeys('ctrl+f,cmd+f', this.handleSearchHotkey);
+    if (this.props.captureHotKeys) {
+      hotkeys('ctrl+f,command+f', this.handleSearchHotkey);
     }
   }
 

--- a/src/components/SearchBar/index.jsx
+++ b/src/components/SearchBar/index.jsx
@@ -11,6 +11,7 @@ import {
   button,
   active,
   inactive,
+  clickable,
 } from './index.module.css';
 
 export default class SearchBar extends Component {
@@ -169,7 +170,7 @@ export default class SearchBar extends Component {
           disabled={disabled}
           className={`react-lazylog-searchbar-filter ${
             filterActive ? 'active' : 'inactive'
-          } ${button} ${filterIcon}`}
+          } ${button} ${filterIcon} ${clickable}`}
           onKeyPress={this.handleKeyPress}
           onMouseUp={this.handleFilterToggle}>
           <FilterLinesIcon />
@@ -179,7 +180,7 @@ export default class SearchBar extends Component {
             <button
               disabled={disabled}
               className={`react-lazylog-searchbar-up-arrow ${
-                resultsCount ? 'active' : 'inactive'
+                resultsCount ? `active ${clickable}` : 'inactive'
               } ${button} ${arrowIcon}`}
               onKeyPress={this.handleKeyPress}
               onMouseUp={onShiftEnter}>
@@ -188,7 +189,7 @@ export default class SearchBar extends Component {
             <button
               disabled={disabled}
               className={`react-lazylog-searchbar-down-arrow ${
-                resultsCount ? 'active' : 'inactive'
+                resultsCount ? `active ${clickable}` : 'inactive'
               } ${button} ${arrowIcon}`}
               onKeyPress={this.handleKeyPress}
               onMouseUp={onEnter}>

--- a/src/components/SearchBar/index.jsx
+++ b/src/components/SearchBar/index.jsx
@@ -159,6 +159,15 @@ export default class SearchBar extends Component {
 
     return (
       <div className={`react-lazylog-searchbar ${searchBar}`}>
+        <span
+          className={`react-lazylog-searchbar-matches ${
+            resultsCount ? 'active' : 'inactive'
+          } ${resultsCount ? active : inactive}`}
+          style={{ marginRight: '10px' }}>
+          {searchLikeBrowser && resultsCount
+            ? `${currentResultsPosition + 1} of ${resultsCount} ${matchesLabel}`
+            : `${resultsCount} ${matchesLabel}`}
+        </span>
         <input
           autoComplete="off"
           type="text"
@@ -200,15 +209,6 @@ export default class SearchBar extends Component {
             </button>
           </Fragment>
         )}
-
-        <span
-          className={`react-lazylog-searchbar-matches ${
-            resultsCount ? 'active' : 'inactive'
-          } ${resultsCount ? active : inactive}`}>
-          {searchLikeBrowser && resultsCount
-            ? `${currentResultsPosition + 1} of ${resultsCount} ${matchesLabel}`
-            : `${resultsCount} ${matchesLabel}`}
-        </span>
       </div>
     );
   }

--- a/src/components/SearchBar/index.jsx
+++ b/src/components/SearchBar/index.jsx
@@ -137,6 +137,12 @@ export default class SearchBar extends Component {
     }
   }
 
+  componentWillUnmount() {
+    if (this.props.captureHotKeys) {
+      hotkeys.deleteScope('all');
+    }
+  }
+
   render() {
     const {
       resultsCount,

--- a/src/components/SearchBar/index.jsx
+++ b/src/components/SearchBar/index.jsx
@@ -56,17 +56,16 @@ export default class SearchBar extends Component {
      */
     onShiftEnter: func,
     /**
-     * If true, search like a browser search - enter jumps to the next line
-     * with the searched term, shift + enter goes backwards.
-     * Also adds up and down arrows to search bar to jump
-     * to the next and previous result.
-     * Defaults to false, which causes enter to toggle the filter instead.
+     * If true, adds up and down arrows to search bar to jump
+     * to the next and previous result. The down arrow calls
+     * "onEnter" and the up arrow calls "onShiftEnter"
+     * Defaults to false, which does not add the arrows.
      */
     searchLikeBrowser: bool,
     /**
      * The current result the browser search is highlighting.
      * Only applicable if searchLikeBrowser is true.
-     * Defaults to 1.
+     * Defaults to 0.
      */
     currentResultsPosition: number,
   };

--- a/src/components/SearchBar/index.jsx
+++ b/src/components/SearchBar/index.jsx
@@ -116,6 +116,7 @@ export default class SearchBar extends Component {
   componentDidMount() {
     if (this.props.captureHotKeys) {
       hotkeys('ctrl+f,command+f', this.handleSearchHotkey);
+      hotkeys.filter = () => true;
     }
   }
 

--- a/src/components/SearchBar/index.jsx
+++ b/src/components/SearchBar/index.jsx
@@ -70,10 +70,6 @@ export default class SearchBar extends Component {
     this.inputRef = createRef();
   }
 
-  handleFilterToggle = () => {
-    this.props.onFilterLinesWithMatches(!this.props.filterActive);
-  };
-
   handleSearchChange = e => {
     const { value: keywords } = e.target;
 
@@ -82,7 +78,6 @@ export default class SearchBar extends Component {
 
   handleKeyPress = e => {
     if (e.key === 'Enter') {
-      // this.handleFilterToggle();
       this.props.onEnter();
     } else if (this.props.captureHotkeys) {
       this.handleSearchHotkey(e);

--- a/src/components/SearchBar/index.module.css
+++ b/src/components/SearchBar/index.module.css
@@ -25,6 +25,11 @@
   fill: #d6d6d6;
 }
 
+.clickable:hover{
+  border-radius: 5px;
+  background: #666666;
+}
+
 .inactive {
   color: #464646;
   fill: #464646;
@@ -34,4 +39,6 @@
   background: none;
   border: none;
   margin-right: 10px;
+  padding: 3px;
+  padding-bottom: 1px;
 }

--- a/src/components/SearchBar/index.module.css
+++ b/src/components/SearchBar/index.module.css
@@ -25,7 +25,7 @@
   fill: #d6d6d6;
 }
 
-.clickable:hover{
+.clickable:hover {
   border-radius: 5px;
   background: #666666;
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -114,6 +114,18 @@ export const searchFormatPart = ({
   nextFormatPart,
   caseInsensitive,
   replaceJsx,
+  // True if this is the line the browser search is highlighting
+  selectedLine,
+  replaceJsxHighlight,
+  /**
+   * highlightedWordLocation is a bit weird, it deals with
+   * the special highlighting of a searched term
+   * if it is the one the browser-like search is currently
+   * highlighting. This is to deal with the case where there are
+   * multiple instances of the searched term in the same line,
+   * to make sure the correct one is highlighted.
+   */
+  highlightedWordLocation,
 }) => part => {
   let formattedPart = part;
 
@@ -121,12 +133,52 @@ export const searchFormatPart = ({
     formattedPart = nextFormatPart(part);
   }
 
+  const exp = new RegExp(`(?=${searchKeywords})`);
+  const splitParts = part.split(exp);
+  // This deals with the special highlighting that occurs when a
+  // line is selected  using the browser search
+  const handleHighlighting = () => {
+    // If this line is selected so we need to deal with special highlighting
+    if (selectedLine) {
+      // This is the special case where the searched
+      // word is at the very start of the string
+      if (splitParts.length === 1) {
+        formattedPart = reactStringReplace(
+          formattedPart,
+          searchKeywords,
+          replaceJsxHighlight
+        );
+      } else {
+        // This highlights the special color
+        // if the word is selected, otherwise, just
+        // the regular matched search term color
+        formattedPart = splitParts.map((part, index) =>
+          reactStringReplace(
+            part,
+            searchKeywords,
+            index === highlightedWordLocation ? replaceJsxHighlight : replaceJsx
+          )
+        );
+      }
+    }
+    // Fianlly, just do regular highlighting since this line isn't selected
+    else {
+      formattedPart = reactStringReplace(
+        formattedPart,
+        searchKeywords,
+        replaceJsx
+      );
+    }
+
+    return formattedPart;
+  };
+
   if (caseInsensitive) {
     if (part.toLowerCase().includes(searchKeywords.toLowerCase())) {
-      return reactStringReplace(formattedPart, searchKeywords, replaceJsx);
+      formattedPart = handleHighlighting();
     }
   } else if (part.includes(searchKeywords)) {
-    return reactStringReplace(formattedPart, searchKeywords, replaceJsx);
+    formattedPart = handleHighlighting();
   }
 
   return formattedPart;

--- a/src/utils.js
+++ b/src/utils.js
@@ -133,7 +133,13 @@ export const searchFormatPart = ({
     formattedPart = nextFormatPart(part);
   }
 
-  const exp = new RegExp(`(?=${searchKeywords})`);
+  // Escape out regex characters so they're treated as normal
+  // characters when we use regex to search for them.
+  const regexKeywords = searchKeywords.replace(
+    /[-[\]{}()*+?.,\\^$|#\s]/g,
+    '\\$&'
+  );
+  const exp = new RegExp(`(?=${regexKeywords})`);
   const splitParts = part.split(exp);
   // This deals with the special highlighting that occurs when a
   // line is selected  using the browser search

--- a/src/utils.js
+++ b/src/utils.js
@@ -142,7 +142,7 @@ export const searchFormatPart = ({
   const exp = new RegExp(`(?=${regexKeywords})`);
   const splitParts = part.split(exp);
   // This deals with the special highlighting that occurs when a
-  // line is selected  using the browser search
+  // line is selected using the browser search
   const handleHighlighting = () => {
     // If this line is selected so we need to deal with special highlighting
     if (selectedLine) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5300,6 +5300,11 @@ hosted-git-info@^2.1.4:
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.4.tgz#44119abaf4bc64692a16ace34700fed9c03e2546"
   integrity sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==
 
+hotkeys-js@^3.7.3:
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/hotkeys-js/-/hotkeys-js-3.7.3.tgz#f0c718166e844b3e52065d1b60cffaa6065b5183"
+  integrity sha512-CSaeVPAKEEYNexYR35znMJnCqoofk7oqG/AOOqWow1qDT0Yxy+g+Y8Hs/LhGlsZaSJ7973YN6/N41LAr3t30QQ==
+
 hpack.js@^2.1.6:
   version "2.1.6"
   resolved "https://registry.yarnpkg.com/hpack.js/-/hpack.js-2.1.6.tgz#87774c0949e513f42e84575b3c45681fade2a0b2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -99,13 +99,6 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-"@mattiasbuelens/web-streams-polyfill@^0.2.0":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@mattiasbuelens/web-streams-polyfill/-/web-streams-polyfill-0.2.1.tgz#d7c4aa94f98084ec0787be084d47167d62ea5f67"
-  integrity sha512-oKuFCQFa3W7Hj7zKn0+4ypI8JFm4ZKIoncwAC6wd5WwFW2sL7O1hpPoJdSWpynQ4DJ4lQ6MvFoVDmCLilonDFg==
-  dependencies:
-    "@types/whatwg-streams" "^0.0.7"
-
 "@neutrinojs/airbnb-base@^8.1.2":
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/@neutrinojs/airbnb-base/-/airbnb-base-8.3.0.tgz#5ebd7f6d63776103c613fa4fbc64bcfa7ae6e7bd"
@@ -425,11 +418,6 @@
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.2.tgz#690a1475b84f2a884fd07cd797c00f5f31356ea8"
   integrity sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==
-
-"@types/whatwg-streams@^0.0.7":
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/@types/whatwg-streams/-/whatwg-streams-0.0.7.tgz#28bfe73dc850562296367249c4b32a50db81e9d3"
-  integrity sha512-6sDiSEP6DWcY2ZolsJ2s39ZmsoGQ7KVwBDI3sESQsEm9P2dHTcqnDIHRZFRNtLCzWp7hCFGqYbw5GyfpQnJ01A==
 
 abbrev@1:
   version "1.1.1"


### PR DESCRIPTION
Adds the ability to specific `searchLikeBrowser={true}` in the base component which adds a browser-like search including
- Pressing Enter to highlight (in pink!) and jump to the next result and Shift + Enter to go to the previous result
- Arrows in the search bar with the same effect as enter and shift enter
- Highlighting of the currently selected result in pink
- Changing "X results" to "X of Y results" while jumping through results

Also removes the polyfill library which was used for backwards comparability with IE because it was giving npm issues on my system. Will look into putting it back in if I can find a work-around.